### PR TITLE
Revised AU280 DDR4 platform and target

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ PCIe accelerators boards that you could use to accelerate your applications, Lit
 | ForestKitten33 | Xilinx Ultrascale+  | XCVU33P       | 125MHz   | PCIe | 2 x 1024-bit 4GB HBM2*|  Gen3 X16     |     ?       |
 | BCU1525        | Xilinx Ultrascale+  | XCVU9P        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen3 X16     |     ?       |
 | AlveoU250      | Xilinx Ultrascale+  | XCU250        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen2 X16     |     ?       |
-| AlveoU280      | Xilinx Ultrascale+  | XCU280        | 125MHz   | PCIe* | 2 x 64-bit DDR4 DIMM* & HBM2*  |  Gen2 X16     |     ?       |
+| AlveoU280 (ES1)      | Xilinx Ultrascale+  | XCU280        | 150MHz   | PCIe* | 2 x 64-bit DDR4 DIMM & HBM2*  |  Gen2 X16     |     ?       |
 
 \* Present on the board but not yet supported or validated with LiteX.
 

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -15,12 +15,12 @@ from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
 _io = [
     # Clk / Rst
     ("sysclk", 0,
-        Subsignal("n", Pins("BJ44"), IOStandard("LVDS")),
-        Subsignal("p", Pins("BJ43"), IOStandard("LVDS")),
+        Subsignal("n", Pins("BJ44"), IOStandard("DIFF_SSTL12")),
+        Subsignal("p", Pins("BJ43"), IOStandard("DIFF_SSTL12")),
     ),
     ("sysclk", 1,
-        Subsignal("n", Pins("BJ6"), IOStandard("LVDS")),
-        Subsignal("p", Pins("BH6"), IOStandard("LVDS")),
+        Subsignal("n", Pins("BJ6"), IOStandard("DIFF_SSTL12")),
+        Subsignal("p", Pins("BH6"), IOStandard("DIFF_SSTL12")),
     ),
 
     ("cpu_reset", 0, Pins("L30"), IOStandard("LVCMOS18")),
@@ -48,16 +48,18 @@ _io = [
     ("ddram", 0,
         Subsignal("a", Pins(
             "BF46 BG43 BK45 BF42 BL45 BF43 BG42 BL43",
-            "BK43 BM42 BG45 BD41 BL42 BE44"),
+            "BK43 BM42 BG45 BD41 BL42 BE44"), # we_n=BE43 cas_n=BL46 ras_n=BH44
             IOStandard("SSTL12_DCI")),
+        Subsignal("we_n", Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
+        Subsignal("cas_n", Pins("BL46"), IOStandard("SSTL12_DCI")), # A15
+        Subsignal("ras_n", Pins("BH44"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("act_n", Pins("BH41"), IOStandard("SSTL12_DCI")),
         Subsignal("ba", Pins("BH45 BM47"), IOStandard("SSTL12_DCI")),
         Subsignal("bg", Pins("BF41 BE41"), IOStandard("SSTL12_DCI")),
-        Subsignal("cas_n", Pins("BL46"), IOStandard("SSTL12_DCI")), # A15
         Subsignal("cke", Pins("BH42"), IOStandard("SSTL12_DCI")),
         Subsignal("clk_n", Pins("BJ46"), IOStandard("DIFF_SSTL12_DCI")),
         Subsignal("clk_p", Pins("BH46"), IOStandard("DIFF_SSTL12_DCI")),
-        Subsignal("cs_n",  Pins("BK46"), IOStandard("SSTL12_DCI")),
+        Subsignal("cs_n", Pins("BK46"), IOStandard("SSTL12_DCI")),
         Subsignal("dq", Pins(
             "BN32 BP32 BL30 BM30 BP29 BP28 BP31 BN31",
             "BJ31 BH31 BF32 BF33 BH29 BH30 BF31 BG32",
@@ -67,40 +69,42 @@ _io = [
             "BE50 BE49 BE51 BD51 BF52 BF51 BG50 BF50",
             "BH50 BJ51 BH51 BH49 BK50 BK51 BJ49 BJ48",
             "BN44 BN45 BM44 BM45 BP43 BP44 BN47 BP47"),
+            # ECC excluded 8 pins
+            # "BG54 BG53 BE53 BE54 BH52 BG52 BK54 BK53"
             IOStandard("POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
             "BN30 BM29 BK30 BG30 BM35 BN35 BK35 BJ32",
             "BM50 BP49 BF48 BG49 BJ47 BK49 BP46 BP42"), #"BJ54 BJ53"
-            IOStandard("DIFF_POD12"),
+            IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "BN29 BM28 BJ29 BG29 BL35 BM34 BK34 BH32",
             "BM49 BP48 BF47 BG48 BH47 BK48 BN46 BN42"), #"BH54 BJ52"
-            IOStandard("DIFF_POD12"),
+            IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("odt", Pins("BG44"), IOStandard("SSTL12_DCI")),
-        Subsignal("ras_n", Pins("BH44"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("reset_n", Pins("BG33"), IOStandard("LVCMOS12")),
-        Subsignal("we_n",  Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
         Misc("SLEW=FAST")
     ),
         ("ddram", 1,
         Subsignal("a", Pins(
             "BF7 BK1 BF6 BF5 BE3 BE6 BE5 BG7",
-            "BJ1 BG2 BJ8 BE4 BL2 BK5"), # BK8 BJ4 BF8
+            "BJ1 BG2 BJ8 BE4 BL2 BK5"), # we_n=BK8 cas_n=BJ4 ras_n=BF8
             IOStandard("SSTL12_DCI")),
+        Subsignal("we_n", Pins("BK8"), IOStandard("SSTL12_DCI")), # A14
+        Subsignal("cas_n", Pins("BJ4"), IOStandard("SSTL12_DCI")), # A15
+        Subsignal("ras_n", Pins("BF8"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("act_n", Pins("BG3"), IOStandard("SSTL12_DCI")),
         Subsignal("ba", Pins("BG8 BK4"), IOStandard("SSTL12_DCI")),
         Subsignal("bg", Pins("BF3 BF2"), IOStandard("SSTL12_DCI")),
-        Subsignal("cas_n", Pins("BJ4"), IOStandard("SSTL12_DCI")), # A15
         Subsignal("cke", Pins("BE1"), IOStandard("SSTL12_DCI")),
         Subsignal("clk_n", Pins("BJ2"), IOStandard("DIFF_SSTL12_DCI")),
         Subsignal("clk_p", Pins("BJ3"), IOStandard("DIFF_SSTL12_DCI")),
-        Subsignal("cs_n",  Pins("BL3"), IOStandard("SSTL12_DCI")),
+        Subsignal("cs_n", Pins("BL3"), IOStandard("SSTL12_DCI")),
         Subsignal("dq", Pins(
             "A11 A10 A9 A8 B12 B10 C12 B11",
             "E11 D11 E12 F11 F10 E9 F9 G11",
@@ -110,25 +114,27 @@ _io = [
             "BJ9 BK9 BK10 BL10 BM9 BN9 BN10 BM10",
             "BM15 BM14 BL15 BM13 BN12 BM12 BP13 BP14",
             "BJ13 BJ12 BH15 BH14 BK14 BK15 BL12 BL13"),
+            # ECC excluded 8 pins
+            # "BE9 BE10 BF10 BE11 BG13 BG12 BG9 BG10"
             IOStandard("POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
-            "A13 D9 G15 D14 BM7 BM8 BN14 BK13",
-            "BF11 C9 G10 K13 D12 BP6 BP8 BP11"), # "BK11 BH9"
-            IOStandard("DIFF_POD12"),
+            "A13 C9 D9 G10 G15 K13 D14 D12",
+            "BM7 BP6 BM8 BP8 BN14 BP11 BK13 BK11"), #"BF11 BH9"
+            #"A13 C9 G15 D14 BM7 BM8 BN14 BK13",
+            #"BF11 C9 G10 K13 D12 BP6 BP8 BP11"), # "BK11 BH9"
+            IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "B13 C10 D10 H10 H15 K14 D15 E13",
-            "BL7 BP7 BL8 BP9 BN15 BP12 BJ14 BJ11"), #"BH54 BJ52"
-            IOStandard("DIFF_POD12"),
+            "BL7 BP7 BL8 BP9 BN15 BP12 BJ14 BJ11"), #"BF12 BH10"
+            IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("odt", Pins("BH2"), IOStandard("SSTL12_DCI")),
-        Subsignal("ras_n", Pins("BF8"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("reset_n", Pins("BH12"), IOStandard("LVCMOS12")),
-        Subsignal("we_n",  Pins("BK8"), IOStandard("SSTL12_DCI")), # A14
         Misc("SLEW=FAST")
     ),
 ]

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -22,7 +22,6 @@ _io = [
         Subsignal("n", Pins("BJ6"), IOStandard("DIFF_SSTL12")),
         Subsignal("p", Pins("BH6"), IOStandard("DIFF_SSTL12")),
     ),
-
     ("cpu_reset", 0, Pins("L30"), IOStandard("LVCMOS18")),
 
     # Leds
@@ -77,13 +76,13 @@ _io = [
         Subsignal("dqs_n", Pins(
             "BN30 BM29 BK30 BG30 BM35 BN35 BK35 BJ32",
             "BM50 BP49 BF48 BG49 BJ47 BK49 BP46 BP42"), #"BJ54 BJ53"
-            IOStandard("DIFF_POD12_DCI"),
+            IOStandard("DIFF_POD12"), # DIFF_POD12_DCI
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "BN29 BM28 BJ29 BG29 BL35 BM34 BK34 BH32",
             "BM49 BP48 BF47 BG48 BH47 BK48 BN46 BN42"), #"BH54 BJ52"
-            IOStandard("DIFF_POD12_DCI"),
+            IOStandard("DIFF_POD12"), # DIFF_POD12_DCI
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("odt", Pins("BG44"), IOStandard("SSTL12_DCI")),
@@ -122,15 +121,13 @@ _io = [
         Subsignal("dqs_n", Pins(
             "A13 C9 D9 G10 G15 K13 D14 D12",
             "BM7 BP6 BM8 BP8 BN14 BP11 BK13 BK11"), #"BF11 BH9"
-            #"A13 C9 G15 D14 BM7 BM8 BN14 BK13",
-            #"BF11 C9 G10 K13 D12 BP6 BP8 BP11"), # "BK11 BH9"
-            IOStandard("DIFF_POD12_DCI"),
+            IOStandard("DIFF_POD12"), # DIFF_POD12_DCI
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "B13 C10 D10 H10 H15 K14 D15 E13",
             "BL7 BP7 BL8 BP9 BN15 BP12 BJ14 BJ11"), #"BF12 BH10"
-            IOStandard("DIFF_POD12_DCI"),
+            IOStandard("DIFF_POD12"), # DIFF_POD12_DCI
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("odt", Pins("BH2"), IOStandard("SSTL12_DCI")),
@@ -174,12 +171,12 @@ class Platform(XilinxPlatform):
         self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 70]")
 
         # Other suggested configurations
-        self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable [current_design]")
-        self.add_platform_command("set_property CONFIG_MODE SPIx4 [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGRATE 85.0 [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN disable [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup [current_design]")
-        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes [current_design]")
+        # self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable [current_design]")
+        # self.add_platform_command("set_property CONFIG_MODE SPIx4 [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGRATE 85.0 [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN disable [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup [current_design]")
+        # self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes [current_design]")

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-# Modified for Alveo U280 by Sergiu Mosanu based on XCU1525 and Alveo U250
+# Modified for Alveo U280 (ES1) by Sergiu Mosanu based on XCU1525 and Alveo U250
 
 from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
 from litex.build.xilinx import XilinxPlatform, VivadoProgrammer

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -21,7 +21,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
 
-from litex.soc.cores.led import LedChaser
+# from litex.soc.cores.led import LedChaser
 from litedram.modules import MTA18ASF2G72PZ
 from litedram.phy import usddrphy
 
@@ -104,10 +104,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("gpio_led"),
-            sys_clk_freq = sys_clk_freq)
-        self.add_csr("leds")
+        # self.submodules.leds = LedChaser(
+        #     pads         = platform.request_all("gpio_led"),
+        #     sys_clk_freq = sys_clk_freq)
+        # self.add_csr("leds")
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -44,7 +44,7 @@ class _CRG(Module):
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(platform.request("sysclk", ddram_channel), 100e6)
         pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
-        pll.create_clkout(self.cd_idelay, 500e6, with_reset=False)
+        pll.create_clkout(self.cd_idelay, 1200e6, with_reset=False)
         platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
 
         self.specials += [
@@ -61,7 +61,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), ddram_channel=0, with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(300e6), ddram_channel=0, with_pcie=False, **kwargs):
         platform = alveo_u280.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ class BaseSoC(SoCCore):
             self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram", ddram_channel),
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
-                iodelay_clk_freq = 500e6,
+                iodelay_clk_freq = 1200e6,
                 is_rdimm         = True)
             self.add_csr("ddrphy")
             self.add_sdram("sdram",
@@ -96,12 +96,12 @@ class BaseSoC(SoCCore):
         self.add_ram("firmware_ram", 0x20000000, 0x8000)
 
         # PCIe -------------------------------------------------------------------------------------
-        if with_pcie:
-            self.submodules.pcie_phy = USPPCIEPHY(platform, platform.request("pcie_x4"),
-                data_width = 128,
-                bar0_size  = 0x20000)
-            self.add_csr("pcie_phy")
-            self.add_pcie(phy=self.pcie_phy, ndmas=1)
+        # if with_pcie:
+        #     self.submodules.pcie_phy = USPPCIEPHY(platform, platform.request("pcie_x4"),
+        #         data_width = 128,
+        #         bar0_size  = 0x20000)
+        #     self.add_csr("pcie_phy")
+        #     self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
         # self.submodules.leds = LedChaser(
@@ -115,7 +115,7 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Alveo U280")
     parser.add_argument("--build",        action="store_true", help="Build bitstream")
     parser.add_argument("--load",         action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq", default=125e6,       help="System clock frequency (default: 125MHz)")
+    parser.add_argument("--sys-clk-freq", default=300e6,       help="System clock frequency (default: 300MHz)")
     parser.add_argument("--ddram-channel",default="0",         help="DDRAM channel (default: 0)")
     parser.add_argument("--with-pcie",    action="store_true", help="Enable PCIe support")
     parser.add_argument("--driver",       action="store_true", help="Generate PCIe driver")

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -44,7 +44,7 @@ class _CRG(Module):
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(platform.request("sysclk", ddram_channel), 100e6)
         pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
-        pll.create_clkout(self.cd_idelay, 1200e6, with_reset=False)
+        pll.create_clkout(self.cd_idelay, 600e6, with_reset=False)
         platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
 
         self.specials += [
@@ -61,7 +61,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(300e6), ddram_channel=0, with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(150e6), ddram_channel=0, with_pcie=False, **kwargs):
         platform = alveo_u280.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ class BaseSoC(SoCCore):
             self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram", ddram_channel),
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
-                iodelay_clk_freq = 1200e6,
+                iodelay_clk_freq = 600e6,
                 is_rdimm         = True)
             self.add_csr("ddrphy")
             self.add_sdram("sdram",
@@ -115,7 +115,7 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Alveo U280")
     parser.add_argument("--build",        action="store_true", help="Build bitstream")
     parser.add_argument("--load",         action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq", default=300e6,       help="System clock frequency (default: 300MHz)")
+    parser.add_argument("--sys-clk-freq", default=150e6,       help="System clock frequency (default: 150MHz)")
     parser.add_argument("--ddram-channel",default="0",         help="DDRAM channel (default: 0)")
     parser.add_argument("--with-pcie",    action="store_true", help="Enable PCIe support")
     parser.add_argument("--driver",       action="store_true", help="Generate PCIe driver")

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2020 Fei Gao <feig@princeton.edu>
 # Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
 # Copyright (c) 2020 David Shah <dave@ds0.me>
-# Modified for Alveo U280 by Sergiu Mosanu based on XCU1525 and Alveo U250
+# Modified for Alveo U280 (ES1) by Sergiu Mosanu based on XCU1525 and Alveo U250
 # SPDX-License-Identifier: BSD-2-Clause
 
 import argparse, os
@@ -80,6 +80,7 @@ class BaseSoC(SoCCore):
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
                 iodelay_clk_freq = 600e6,
+                cmd_latency      = 1,
                 is_rdimm         = True)
             self.add_csr("ddrphy")
             self.add_sdram("sdram",


### PR DESCRIPTION
Numerous fixes are included. At this time reads and writes are successful as long as they are 8Bytes long or shorter. The clk frequency was increased to 150MHz.